### PR TITLE
allow disabling defmt dependency at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ embedded-hal = "0.2.7"
 
 [dependencies.defmt]
 version = "0.3.6"
+optional = true
 
 [dependencies.crc-any]
 version = "2.4.4"
@@ -28,3 +29,7 @@ embedded-hal-mock =  "0.8.0"
 [dev-dependencies.defmt]
 version = "0.3.6"
 features = ["unstable-test"]
+
+[features]
+default = ["use-defmt"]
+use-defmt = ["dep:defmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,10 +345,12 @@ where
 
         while !self.check_status()?.is_calibrated() {
             self.send_initialize()?;
+            #[cfg(feature = "use-defmt")]
             defmt::debug!("init: waiting for sensor to report being calibrated, 10ms.");
             delay.delay_ms(10_u16);
         }
 
+        #[cfg(feature = "use-defmt")]
         defmt::debug!("init: sensor reporting being calibrated, init done.");
         Ok(AHT20Initialized { aht20: self })
     }
@@ -365,6 +367,7 @@ where
     ///
     /// This is used by both measure_once and init.
     fn check_status(&mut self) -> Result<SensorStatus, Error<E>> {
+        #[cfg(feature = "use-defmt")]
         defmt::debug!("check_status: requesting a status check from sensor.");
         let mut read_buffer = [0u8; 1];
 
@@ -381,6 +384,7 @@ where
     /// After sending initialize, there is a required 40ms wait period and verification
     /// that the sensor reports itself calibrated. See the `init` method.
     fn send_initialize(&mut self) -> Result<(), Error<E>> {
+        #[cfg(feature = "use-defmt")]
         defmt::debug!("send_initialize: requesting sensor to initialize itself.");
         let command: [u8; 3] = [
             // Initialize = 0b1011_1110. Equivalent to 0xBE, Section 5.3, page 8, Table 9
@@ -470,10 +474,12 @@ where
                 }
                 Err(Error::InvalidCrc) => {
                     // CRC failed to validate, we'll go back and issue another read request.
+                    #[cfg(feature = "use-defmt")]
                     defmt::error!("Invalid CRC, retrying.");
                 }
                 Err(Error::UnexpectedBusy) => {
                     // Possibly indicates the previously seen 'ready' was due to uncorrected noise.
+                    #[cfg(feature = "use-defmt")]
                     defmt::error!("Sensor contradicted a ready status with a crc-checked busy.");
                 }
                 Err(other) => return Err(other),
@@ -502,10 +508,12 @@ where
                 }
                 Err(Error::InvalidCrc) => {
                     // CRC failed to validate, we'll go back and issue another read request.
+                    #[cfg(feature = "use-defmt")]
                     defmt::error!("Invalid CRC, retrying.");
                 }
                 Err(Error::UnexpectedBusy) => {
                     // Possibly indicates the previously seen 'ready' was due to uncorrected noise.
+                    #[cfg(feature = "use-defmt")]
                     defmt::error!("Sensor contradicted a ready status with a crc-checked busy.");
                 }
                 Err(other) => return Err(other),
@@ -526,6 +534,7 @@ where
 
         // Wait for measurement to be ready
         while !self.aht20.check_status()?.is_ready() {
+            #[cfg(feature = "use-defmt")]
             defmt::debug!("measure_once: waiting for ready, 1ms.");
             delay.delay_ms(1_u16);
         }


### PR DESCRIPTION
Fixes https://github.com/anglerud/aht20-driver/issues/9

This introduces a cargo feature `use-defmt` which gates the use of the `defmt` crate. This feature is enabled by default. To disable it, set `default-features = false` for `aht20-driver` in the `[dependencies]` section of `Cargo.toml`.