### PR TITLE
implement core::error::Error for Error<E>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://github.com/anglerud/aht20-driver"
 repository = "https://github.com/anglerud/aht20-driver"
 documentation = "https://docs.rs/aht20-driver"
 readme = "README.md"
+rust-version = "1.81"
 
 [dependencies]
 embedded-hal = "0.2.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,19 @@ pub enum Error<E> {
     Internal,
 }
 
+impl<E> core::fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        match self {
+            Error::I2c(_e) => write!(f, "I2C error"),
+            Error::InvalidCrc => write!(f, "invalid CRC error"),
+            Error::UnexpectedBusy => write!(f, "unexpected busy error"),
+            Error::Internal => write!(f, "internal ATH20 driver error"),
+        }
+    }
+}
+
+impl<E> core::error::Error for Error<E> where E: core::fmt::Debug {}
+
 /// An AHT20 sensor on the I2C bus `I`.
 ///
 /// The address of the sensor will be `SENSOR_ADDRESS` from this package, unless there is some kind


### PR DESCRIPTION
Rust 1.81 stabilized the `Error` trait in `core`, allowing usage of the trait in `#![no_std]` libraries such as `aht20-driver`. This PR introduces a dependency on 1.81 and implements `core::error::Error` for the `aht20_driver::Error<E>`.